### PR TITLE
Cache node_modules Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
 - node
 services:
 - mongodb
+cache:
+  directories:
+    - node_modules
 deploy:
   provider: heroku
   api_key:


### PR DESCRIPTION
Updated the travis.yaml so that Travis CI caches the node modules for faster builds.